### PR TITLE
Better Injection Script w/ Dynamic Hook Code

### DIFF
--- a/Scripts/injector.sh
+++ b/Scripts/injector.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 LIB_NAME=ac_detour
-LIB_PATH=$(pwd)/$LIB_NAME.so
+LIB_PATH=$(pwd)/../Bin/$LIB_NAME.so
 PROCID=$(pgrep native_client | head -n 1)
 
 # Check if gdb is installed
@@ -44,18 +44,33 @@ unload() {
     fi
 
     gdb -n --batch -ex "attach $PROCID" \
-                   -ex "call ((int (*) (void *)) dlclose)($LIB_HANDLE)" \
+                   -ex "call dlclose($LIB_HANDLE)" \
                    -ex "detach" > /dev/null 2>&1
 
     echo "Library has been unloaded!"
 }
 
-trap unload SIGINT
+if [ "$#" -gt 0 ]; then
+    LIB_HANDLE=$(gdb -n --batch -ex "attach $PROCID" \
+                                -ex "set \$detour_handler = dlopen(\"$LIB_PATH\", 1)" \
+                                -ex "print/x \$detour_handler" \
+                                -ex "source injector_gdb_setup.py" | grep -oP '\$1 = \K0x[0-9a-f]+')
 
-LIB_HANDLE=$(gdb -n --batch -ex "attach $PROCID" \
-                            -ex "set \$detour_handler = dlopen(\"$LIB_PATH\", 1)" \
-                            -ex "call (void *) \$detour_handler" \
-                            -ex "detach" | grep -oP '\$1 = \(void \*\) \K0x[0-9a-f]+')
+    gdb -ex "attach $PROCID" \
+        -ex "call init()" \
+        -ex "printf \"\nYou are running this injection script in interactive mode.\nBy default it will open hook resources and call 'init()' constructor.\nWhen you run 'Quit' shared library will be closed by script.\n\n\""
+
+    unload
+    exit 0
+else
+    trap unload SIGINT
+    LIB_HANDLE=$(gdb -n --batch -ex "attach $PROCID" \
+                                -ex "set \$detour_handler = dlopen(\"$LIB_PATH\", 1)" \
+                                -ex "print/x \$detour_handler" \
+                                -ex "source injector_gdb_setup.py" \
+                                -ex "call init()" \
+                                -ex "detach" | grep -oP '\$1 = \K0x[0-9a-f]+')
+fi
 
 if [ -z "$LIB_HANDLE" ]; then
     echo "Failed to load library"

--- a/Scripts/injector.sh
+++ b/Scripts/injector.sh
@@ -52,7 +52,7 @@ unload() {
 
 if [ "$#" -gt 0 ]; then
     LIB_HANDLE=$(gdb -n --batch -ex "attach $PROCID" \
-                                -ex "set \$detour_handler = dlopen(\"$LIB_PATH\", 1)" \
+                                -ex "set \$detour_handler = (void *(*) (const char*, int))dlopen(\"$LIB_PATH\", 1)" \
                                 -ex "print/x \$detour_handler" \
                                 -ex "source injector_gdb_setup.py" | grep -oP '\$1 = \K0x[0-9a-f]+')
 
@@ -65,7 +65,7 @@ if [ "$#" -gt 0 ]; then
 else
     trap unload SIGINT
     LIB_HANDLE=$(gdb -n --batch -ex "attach $PROCID" \
-                                -ex "set \$detour_handler = dlopen(\"$LIB_PATH\", 1)" \
+                                -ex "set \$detour_handler = (void *(*) (const char*, int))dlopen(\"$LIB_PATH\", 1)" \
                                 -ex "print/x \$detour_handler" \
                                 -ex "source injector_gdb_setup.py" \
                                 -ex "call init()" \

--- a/Scripts/injector_gdb_setup.py
+++ b/Scripts/injector_gdb_setup.py
@@ -1,0 +1,60 @@
+#
+# This script is meant to be run by the GDB process inside fellow script
+# 'injector.sh', it dynamically sets otherwise hardcoded values like
+# function addresses and instruction patch sizes.
+#
+# Not using 'injector.sh' (just 'ac_detour.so') may not work on all AC exes.
+#
+
+import gdb
+
+instruction_patch_idx = str(int(gdb.parse_and_eval('AC_detour::injection_offset')))
+instruction_patch_size = str(int(gdb.parse_and_eval('AC_detour::hook_instruction_length')))
+
+###############################################################################
+#
+# Setting addresses of functions we want
+#
+gdb.execute('set hook_util.check_input_address = &checkinput')
+
+###############################################################################
+#
+# Extracting the instructions that will get patched out, via GDB output, so we
+# can modify the default hook instruction length
+#
+def get_instruction_line_addr(line):
+    addr_idx = line.find("0x")
+    addr_end_idx = line.find("<") - 1
+    try: return int(line[addr_idx:addr_end_idx], 16)
+    except: return 0
+
+def get_instruction(line):
+    addr_idx = line.find(">:\t") + 3
+    addr_end_idx = len(line)
+    try: return line[addr_idx:addr_end_idx]
+    except: return None
+
+# Basically will go through instructions until we hit instruction that will not
+# be overwritten by trampoline jump
+prev_addr = None
+instructions = []
+instruction_sizes = 0
+
+for line in gdb.execute('x/%si (&checkinput+%s)' % (instruction_patch_size, instruction_patch_idx), to_string=True).splitlines():
+    instructions.append(' '.join(get_instruction(line).split()))
+    if prev_addr == None:
+        prev_addr = get_instruction_line_addr(line)
+        continue
+    instr_addr = get_instruction_line_addr(line)
+    cur_size = instr_addr - prev_addr
+    prev_addr = instr_addr
+    instruction_sizes += cur_size
+
+    # We have the instructions that will be patched out
+    if instruction_sizes >= int(instruction_patch_size):
+        instructions = instructions[:-1]
+        break
+
+# Our new hook instruction length should be the length of FULL instruction
+# bytes we overwrite
+gdb.execute('set AC_detour::hook_instruction_length = %d' % instruction_sizes)

--- a/Src/ac_detour.cpp
+++ b/Src/ac_detour.cpp
@@ -1,5 +1,8 @@
 #include "ac_detour.h"
 
+__uint64_t AC_detour::injection_offset = 17;
+__uint8_t AC_detour::hook_instruction_length = 17;
+
 void AC_detour::find_target_page() {
     pid_t pid = getpid();
     std::ostringstream mapping;
@@ -50,17 +53,24 @@ void AC_detour::formulate_detour_instructions() {
 
 void AC_detour::inject_detour_instructions() 
 {
-    original_instructions = new __uint8_t[AC_detour::hook_instruction_length];
+    original_instructions = mmap(nullptr, AC_detour::hook_instruction_length+2, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (original_instructions == MAP_FAILED) {
+        perror("mmap error");
+        return;
+    }
     hook_location = (void*)(check_input_address+injection_offset);
 
     std::memcpy(original_instructions, hook_location, AC_detour::hook_instruction_length);
+    // JMP RDX
+    reinterpret_cast<__uint8_t*>(original_instructions)[AC_detour::hook_instruction_length] = 0xFF;
+    reinterpret_cast<__uint8_t*>(original_instructions)[AC_detour::hook_instruction_length+1] = 0xE2;
 
     if (mprotect((void*)page_number, AC_detour::target_page_size, PROT_READ | PROT_WRITE | PROT_EXEC) != 0)
     {
         perror("mprotect error");
         return; 
     }
-    std::memcpy(hook_location, hook_instruction, AC_detour::hook_instruction_length);  // hook
+    std::memcpy(hook_location, hook_instruction, AC_detour::hook_instruction_length); // hook
 
     mprotect((void*)page_number, AC_detour::target_page_size, PROT_READ | PROT_EXEC);
 }

--- a/Src/ac_detour.h
+++ b/Src/ac_detour.h
@@ -19,14 +19,16 @@ private:
     void inject_detour_instructions();
 
 public:
-    static const __uint64_t injection_offset = 17;
-    static const __uint8_t hook_instruction_length = 17;
     static const __uint64_t target_page_size = 0x13D000;
     static const __uint64_t check_input_offset = 0x69B00;
 
+    // Set at top of source file
+    static __uint64_t injection_offset;
+    static __uint8_t hook_instruction_length;
+
     __uint64_t check_input_address;
     __uint64_t page_number;
-    __uint8_t *original_instructions;
+    void *original_instructions;
 
     AC_detour(__uint64_t trampoline_function_addr);
 };


### PR DESCRIPTION
Here are the changes:
- `injector.sh` script now has an interactive mode. Providing any argument to it will bring up the GDB terminal so you can debug. No arguments makes the script work as intended.

- `injector_gdb_setup.py` is a GDB script that `injector.sh` uses to dynamically change certain global values from the hook shared library. It gives the shared library the pointer to `checkinput()`, and the amount of bytes of instructions it patched out. The raw shared library without injection script will use hardcoded values that may not work on every AC executable.

- Some constants were turned into global so that the scripts could modify them before `init()` gets called (this is called manually now but `unload()` is still called dynamically).

This script works well on my game, accept this PR if it works well on yours too. Also, it would be preferable if from now on any AC function address (or other relevant symbol addresses) are stored in some kind of global value that way the scripts can dynamically change them. Like if you add a `setskin()` address. Thanks.