### PR TITLE
Add capabilities for unpress events

### DIFF
--- a/Src/Environment_Interaction.cpp
+++ b/Src/Environment_Interaction.cpp
@@ -1,12 +1,19 @@
 #include "Environment_Interaction.h"
 
-int Environment_Interaction::Keyboard_Event(__uint32_t key)
+int Environment_Interaction::Keyboard_Event(__uint32_t key, bool isPressed)
 {
     SDL_Event event;
-    event.type = this->sdl_util.SDL_KEYDOWN;
+    if (isPressed) {
+        event.type = this->sdl_util.SDL_KEYDOWN;
+        event.key.type = this->sdl_util.SDL_KEYDOWN;
+        event.key.state = this->sdl_util.SDL_PRESSED;
+    }
+    else {
+        event.type = this->sdl_util.SDL_KEYUP;
+        event.key.type = this->sdl_util.SDL_KEYUP;
+        event.key.state = this->sdl_util.SDL_RELEASED;
+    }
 
-    event.key.type = this->sdl_util.SDL_KEYDOWN;
-    event.key.state = this->sdl_util.SDL_PRESSED;
     event.key.repeat = 0;
     event.key.keysym.sym = key;
     event.key.keysym.scancode = key - this->sdl_util.scancode_offset;
@@ -20,7 +27,6 @@ int Environment_Interaction::Mouse_Motion_Event(__uint32_t dx, __uint32_t dy)
 {
     SDL_Event event;
     event.type = this->sdl_util.SDL_MOUSEMOTION;
-
     event.motion.type = this->sdl_util.SDL_MOUSEMOTION;
     event.motion.state = 0;
     this->sdl_util.SDL_GetMouseState(&event.motion.x, &(event.motion.y));
@@ -30,17 +36,24 @@ int Environment_Interaction::Mouse_Motion_Event(__uint32_t dx, __uint32_t dy)
     return this->sdl_util.SDL_PushEvent(&event);
 }
 
-    // no arguments becuase were just telling the game to fire the gun
-int Environment_Interaction::Mouse_Button_Event()
+int Environment_Interaction::Mouse_Button_Event(bool isPressed)
 {
     SDL_Event event;
-    event.type = this->sdl_util.SDL_MOUSEBUTTONDOWN;
+    if (isPressed) {
+        event.type = this->sdl_util.SDL_MOUSEBUTTONDOWN;
+        event.button.type = this->sdl_util.SDL_MOUSEBUTTONDOWN;
+        event.button.state = this->sdl_util.SDL_PRESSED;
+    }
+    else {
+        event.type = this->sdl_util.SDL_MOUSEBUTTONUP;
+        event.button.type = this->sdl_util.SDL_MOUSEBUTTONUP;
+        event.button.state = this->sdl_util.SDL_RELEASED;
+    }
 
-    event.button.type = this->sdl_util.SDL_MOUSEBUTTONDOWN;
     event.button.button = this->sdl_util.SDL_BUTTON_LEFT;
-    event.button.state = this->sdl_util.SDL_PRESSED;
     event.button.clicks = 1;
     this->sdl_util.SDL_GetMouseState(&event.motion.x, &(event.motion.y));    
     event.button.which = this->sdl_util.SDL_TOUCH_MOUSEID;
+
     return this->sdl_util.SDL_PushEvent(&event);
 }

--- a/Src/Environment_Interaction.h
+++ b/Src/Environment_Interaction.h
@@ -7,9 +7,8 @@ class Environment_Interaction
 public:
     SDL sdl_util;
 
-    int Keyboard_Event(__uint32_t key);
+    int Keyboard_Event(__uint32_t key, bool isPressed);
     // dx and dy are movements on x,y plane of the mouse and also changes in yaw and pitch respectively
     int Mouse_Motion_Event(__uint32_t dx, __uint32_t dy);
-    // no arguments becuase were just telling the game to fire the gun
-    int Mouse_Button_Event();
+    int Mouse_Button_Event(bool isPressed);
 };

--- a/Src/sdl_lib.h
+++ b/Src/sdl_lib.h
@@ -61,10 +61,13 @@ typedef union SDL_Event
 struct SDL
 {
     int scancode_offset = 93;
+    __uint8_t SDL_RELEASED = 0;
     __uint8_t SDL_PRESSED = 1;
     __uint32_t SDL_KEYDOWN = 0x300;
+    __uint32_t SDL_KEYUP = 0x301;
     __uint32_t SDL_MOUSEMOTION = 0x400;
     __uint32_t SDL_MOUSEBUTTONDOWN = 0x401;
+    __uint32_t SDL_MOUSEBUTTONUP = 0x402;
     __uint32_t SDL_BUTTON_LEFT = 1;
     __uint32_t SDL_TOUCH_MOUSEID = ((__uint32_t)-1);
 


### PR DESCRIPTION
`Keyboard_Event` and `Mouse_Button_Event` now have an argument `isPressed`.

When you want a key or mouse-left-button pressed you set this to true. When you want to unpress them you set this to false. If you never unpress them then the game thinks you are permanently pressing something, even if you only added one event.